### PR TITLE
chore: change node versions for CI build, and avoid `any`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 dist
 node_modules
 .sftp.json
+.vscode

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,14 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
-import { Client } from 'ssh2';
-import SshClient from 'ssh2-sftp-client';
+import SftpClient from 'ssh2-sftp-client';
 import tmp from 'tmp-promise';
 
 import { compressDirectory } from './compress-directory';
 import { deployToStaging } from './deploy-to-staging';
 import { swapStagingWithProduction } from './swap-staging-with-production';
 import { SftpDeployConfig } from './types/config';
+import { SftpClientWithSsh } from './types/sftp-client-with-ssh';
 import { uploadFile } from './upload-file';
 import { noop } from './util/noop';
 
@@ -46,7 +46,7 @@ export async function sftpDeployer(config: SftpDeployConfig): Promise<void> {
                 : await fs.readFile(path.resolve(localDir, config.privateKeyFile), {
                       encoding: 'utf-8'
                   });
-        const sftpClient = new SshClient();
+        const sftpClient = new SftpClient() as SftpClientWithSsh;
 
         const startConnect = new Date().getTime();
         await sftpClient.connect({
@@ -55,7 +55,7 @@ export async function sftpDeployer(config: SftpDeployConfig): Promise<void> {
             port,
             privateKey
         });
-        const sshClient = (sftpClient as any).client as Client;
+        const sshClient = sftpClient.client;
         const elapsedConnect = 0.001 * (new Date().getTime() - startConnect);
         succeed(`Connected to ${chalk.cyan(`${host}:${port}`)} ${chalk.gray(`[${elapsedConnect.toFixed(1)}s]`)}`);
 

--- a/src/swap-staging-with-production.ts
+++ b/src/swap-staging-with-production.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
-import { Client } from 'ssh2';
-import SshClient from 'ssh2-sftp-client';
+
 import { sshExecCommand } from './ssh-exec-cmd';
+import { SftpClientWithSsh } from './types/sftp-client-with-ssh';
 
 export interface SwapStagingWithProductionOptions {
-    sftpClient: SshClient;
+    sftpClient: SftpClientWithSsh;
     targetDir: string;
     stagingDir: string;
     progress: (text: string) => void;
@@ -18,7 +18,7 @@ export async function swapStagingWithProduction({
     progress,
     succeed
 }: SwapStagingWithProductionOptions): Promise<void> {
-    const sshClient = (sftpClient as any).client as Client;
+    const sshClient = sftpClient.client;
     progress('Swapping staging and production...');
     const targetDirExists = !!(await sftpClient.exists(targetDir));
     if (targetDirExists) {

--- a/src/types/sftp-client-with-ssh.ts
+++ b/src/types/sftp-client-with-ssh.ts
@@ -1,0 +1,6 @@
+import { Client } from 'ssh2';
+import SftpClient from 'ssh2-sftp-client';
+
+export interface SftpClientWithSsh extends SftpClient {
+    client: Client;
+}

--- a/src/upload-file.spec.ts
+++ b/src/upload-file.spec.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import SshClient from 'ssh2-sftp-client';
+import SftpClient from 'ssh2-sftp-client';
 import tmp from 'tmp-promise';
 
 import { uploadFile } from './upload-file';
@@ -32,7 +32,7 @@ describe('uploadFile', () => {
         });
         const sftpClient = {
             fastPut
-        } as unknown as SshClient;
+        } as unknown as SftpClient;
         await uploadFile({
             sftpClient,
             localFilePath: tempFile.path,

--- a/src/upload-file.ts
+++ b/src/upload-file.ts
@@ -1,10 +1,10 @@
 import bytes from 'bytes';
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import SshClient from 'ssh2-sftp-client';
+import SftpClient from 'ssh2-sftp-client';
 
 interface UploadFileOpts {
-    sftpClient: SshClient;
+    sftpClient: SftpClient;
     localFilePath: string;
     remoteFilePath: string;
     progress: (text: string) => void;


### PR DESCRIPTION
Only run CI builds on node 12, 14 and 16 (LTS)